### PR TITLE
Handle empty size cmd output from r2

### DIFF
--- a/diaphora_r2.py
+++ b/diaphora_r2.py
@@ -209,7 +209,11 @@ def GetCommentEx(x, type):
   return r2.cmd("CC.@ %s"%(x))
 
 def diaphora_decode(x):
-  decoded_size = int(r2.cmd("ao~size[1]"))
+  r2_cmd_output = r2.cmd("ao~size[1]")
+  if r2_cmd_output == "":
+      decoded_size = 1
+  else:
+      decoded_size = int(r2_cmd_output)
   #opinfo = r2.cmdj("aoj")
   ins = {'Operands': []}
   #ins["Operands"] = [ ] # XXX
@@ -295,7 +299,10 @@ def GetDisasm(x):
   return r2.cmd('pi 1 @ %s'%(x))
 
 def ItemSize(x):
-  return int(r2.cmd('ao~size[1]'), 16)
+  r2_cmd_output = r2.cmd('ao~size[1]')
+  if r2_cmd_output == '':
+      return 1
+  return int(r2_cmd_output, 16)
 #-----------------------------------------------------------------------
 def askyn_c(a, b):
   # It doesn't make any sense to me for the r2 exporter. askyn_c is used

--- a/diaphora_r2.py
+++ b/diaphora_r2.py
@@ -74,6 +74,9 @@ def block_succs(addr):
   except:
     print("NO BASIC BLOCK AT %s"%(addr))
     return res
+  if bb == None:
+    print("EMPTY BB LIST FOR %s"%(addr))
+    return res
   bb = bb[0]
   try:
     res.append(int(bb["jump"]))


### PR DESCRIPTION
I'm running a new version of radare2 (radare2 2.3.0-git 16954) and got exceptions when analyzing a binary with `diaphora_r2.py`.

Sometimes the command `ao~size[1]` returns an empty response. If I add a fallback to return 1 then things seems to work.

I'm not sure if this is the proper way to solve the problem but I thought that making a PR instead of just an issue could be helpful. Feel free to solve this in a completely different way if you think that's the way to go :smile:.